### PR TITLE
JShint was ignoring my code encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,4 +97,13 @@
 	    </developer>
 	</developers>
         <!--   END: STUFF REQUIRED BY THE CENTRAL REPO -->
+        
+        <contributors>
+          <contributor>
+            <name>Marvin Froeder</name>
+            <email>velo.br@gmail.com</email>
+            <url>about.me/velo</url>
+          </contributor>
+        </contributors>
+        
 </project>

--- a/src/main/java/com/cj/jshintmojo/Mojo.java
+++ b/src/main/java/com/cj/jshintmojo/Mojo.java
@@ -7,7 +7,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -36,6 +38,7 @@ import com.cj.jshintmojo.reporter.JSHintReporter;
 import com.cj.jshintmojo.reporter.JSLintReporter;
 import com.cj.jshintmojo.util.OptionsParser;
 import com.cj.jshintmojo.util.Util;
+
 import java.util.Collections;
 
 /**
@@ -96,6 +99,11 @@ public class Mojo extends AbstractMojo {
 	private Boolean failOnError = true;
 
 	/**
+	 * @parameter default-value="${project.build.sourceEncoding}" 
+	 */
+	private String encoding;
+
+	/**
 	 * @parameter default-value="${basedir}
 	 * @readonly
 	 * @required
@@ -123,7 +131,7 @@ public class Mojo extends AbstractMojo {
 
 	    final String jshintCode = getEmbeddedJshintCode(version);
 	    
-        final JSHint jshint = new JSHint(jshintCode);
+        final JSHint jshint = new JSHint(jshintCode, encoding);
 
         final Config config = readConfig(this.options, this.globals, this.configFile, this.basedir, getLog());
         if (this.excludes.isEmpty() || (this.ignoreFile != null && !this.ignoreFile.isEmpty())) {
@@ -243,14 +251,14 @@ public class Mojo extends AbstractMojo {
         return matches;
     }
 
-    private static Map<String, Result> lintTheFiles(final JSHint jshint, final Cache cache, List<File> filesToCheck, final Config config, final Log log) throws FileNotFoundException {
+    private static Map<String, Result> lintTheFiles(final JSHint jshint, final Cache cache, List<File> filesToCheck, final Config config, final Log log ) throws FileNotFoundException {
         final Map<String, Result> currentResults = new HashMap<String, Result>();
         for(File file : filesToCheck){
         	Result previousResult = cache.previousResults.get(file.getAbsolutePath());
         	Result theResult;
         	if(previousResult==null || (previousResult.lastModified.longValue()!=file.lastModified())){
         		log.info("  " + file );
-        		List<Error> errors = jshint.run(new FileInputStream(file), config.options, config.globals);
+				List<Error> errors = jshint.run(new FileInputStream(file), config.options, config.globals );
         		theResult = new Result(file.getAbsolutePath(), file.lastModified(), errors); 
         	}else{
         		log.info("  " + file + " [no change]");

--- a/src/main/java/com/cj/jshintmojo/jshint/JSHint.java
+++ b/src/main/java/com/cj/jshintmojo/jshint/JSHint.java
@@ -15,9 +15,16 @@ import com.cj.jshintmojo.util.Rhino;
 public class JSHint {
     
     private final Rhino rhino;
-    
-    public JSHint(String jshintCode) {
-        
+
+    private String encoding;
+
+    public JSHint(String jshintVersion) {
+        this(jshintVersion, System.getProperty("file.encoding"));
+    }
+
+    public JSHint(String jshintCode, String encoding) {
+        this.encoding = encoding;
+
         rhino = new Rhino();
         try {
             rhino.eval(
@@ -25,13 +32,13 @@ public class JSHint {
             		"quit=function(){};" +
             		"arguments=[];");
             
-            rhino.eval(commentOutTheShebang(resourceAsString(jshintCode)));
+            rhino.eval(commentOutTheShebang(resourceAsString(jshintCode, encoding)));
         } catch (EcmaError e) {
             throw new RuntimeException("Javascript eval error:" + e.getScriptStackTrace(), e);
         }
     }
 
-    private String commentOutTheShebang(String code) {
+	private String commentOutTheShebang(String code) {
         String minusShebang = code.startsWith("#!")?"//" + code : code;
         return minusShebang;
     }
@@ -39,7 +46,7 @@ public class JSHint {
     public List<Error> run(InputStream source, String options, String globals) {
         final List<Error> results = new ArrayList<JSHint.Error>();
 
-        String sourceAsText = toString(source);
+        String sourceAsText = toString(source, encoding);
 
         NativeObject nativeOptions = toJsObject(options);
         NativeObject nativeGlobals = toJsObject(globals);
@@ -91,16 +98,16 @@ public class JSHint {
         return nativeOptions;
     }
 
-    private static String toString(InputStream in) {
+    private static String toString(InputStream in, String encoding) {
         try {
-            return IOUtils.toString(in);
+            return IOUtils.toString(in, encoding);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    private String resourceAsString(String name) {
-        return toString(getClass().getResourceAsStream(name));
+    private String resourceAsString(String name, String encoding) {
+        return toString(getClass().getResourceAsStream(name), encoding);
     }
 
     @SuppressWarnings("unchecked") 


### PR DESCRIPTION
Hi,

I'm running JSHint on a project and it start failing on windows machines with the following error:
"This character may get silently deleted by one or more browsers."

It turns out, the plugin was ignoring maven enconding.

Add a parameter to allow setting my enconding (or using the one already set for maven).