### PR TITLE
Now report file's parent directory is created if not exists.

### DIFF
--- a/src/main/java/com/cj/jshintmojo/Mojo.java
+++ b/src/main/java/com/cj/jshintmojo/Mojo.java
@@ -336,6 +336,7 @@ public class Mojo extends AbstractMojo {
         }
         File file = StringUtils.isNotBlank(reportFile) ?
                 new File(reportFile) : new File("target/jshint.xml");
+        mkdirs(file.getParentFile());
         getLog().info(String.format("Generating \"JSHint\" report. reporter=%s, reportFile=%s.",
                 reportType, file.getAbsolutePath()));
 


### PR DESCRIPTION
We had a problem during build when the report file's parent directory does not exist yet.

[INFO] Generating "JSHint" report. reporter=checkstyle, reportFile=/home/<HIDDEN>/reports/jshint.xml.
[ERROR] 
java.io.FileNotFoundException: reports/jshint.xml (No such file or directory)
	at java.io.FileOutputStream.open(Native Method)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:221)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:171)
	at com.cj.jshintmojo.Mojo.saveReportFile(Mojo.java:304)
	at com.cj.jshintmojo.Mojo.handleResults(Mojo.java:265)
	at com.cj.jshintmojo.Mojo.execute(Mojo.java:140)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:320)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)

Now parent directory will be created before file is opened for writing. I would appreciate if you merge this commits. Feel free to contact me.

Greetings
Cornelius