### PR TITLE
Use Plexus file exclusion patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ It's real simple and it runs [JSHint](http://www.jshint.com/) on your *.js files
 | globals         |                               | List of comma-separated [JSHint globals](http://www.jshint.com/docs/#usage) |
 | configFile      |                               | Path to a JSHint JSON config file. Its contents will override values set in `options` and `globals`, if present. Please note that block and line comments will be stripped prior to processing so it's OK to include them. |
 | directories     | `<directory>src</directory>`  | Locations in which the plugin will search for *.js files |
-| excludes        |                               | Excludes are resolved relative to the basedir of the module |
+| excludes        |                               | Excludes are resolved relative to the source directories. Standard maven semantics apply. |
+| includes        |                               | Includes are resolved relative to the source directories. Standard maven semantics apply. Default inclusion rule is: "**/*.js" |
 | reporter        |                               | If present, JSHint will generate a reporting file which can be used for some CI tools. Currently, `jslint`, `html`, and `checkstyle` formats are supported. |
 | reportFile      | target/jshint.xml             | Path to an output reporting file |
 | failOnError     | `true`                          | Controls whether the plugin fails the build when JSHint is unhappy. Setting this to `false` is discouraged, as it removes most of the benefit of using this plugin. Instead, if you have problem files that you can't fix [disable/override JSHint on a per-file basis](http://www.jshint.com/docs/#config), or tell the plugin to specifically exclude them in the `excludes` section |
@@ -43,7 +44,11 @@ It's real simple and it runs [JSHint](http://www.jshint.com/) on your *.js files
          <excludes>
               <exclude>src/main/webapp/hackyScript.js</exclude>
               <exclude>src/main/webapp/myDirectoryForThirdyPartyStuff</exclude>
+              <exclude>**/*.min.js</exclude>
          </excludes>
+         <includes>
+            <include>**/*.js</include>
+         </includes>
          <reporter>jslint</reporter>
          <reportFile>target/jshint.xml</reportFile>
          <failOnError>false</failOnError>

--- a/src/main/java/com/cj/jshintmojo/cache/Cache.java
+++ b/src/main/java/com/cj/jshintmojo/cache/Cache.java
@@ -16,8 +16,9 @@ public class Cache implements Serializable {
 	    public final String configFile;
 	    public final List<String> directories;
 	    public final List<String> excludes;
+        public final List<String> includes;
         
-	    public Hash(String options, String globals, String jsHintVersion, String configFile, List<String> directories, List<String> excludes) {
+	    public Hash(String options, String globals, String jsHintVersion, String configFile, List<String> directories, List<String> excludes, List<String> includes) {
             super();
             this.options = options;
             this.globals = globals;
@@ -25,6 +26,7 @@ public class Cache implements Serializable {
             this.configFile = configFile;
             this.directories = directories;
             this.excludes = excludes;
+            this.includes = includes;
         }
 	}
 	

--- a/src/test/java/com/cj/jshintmojo/MojoTest.java
+++ b/src/test/java/com/cj/jshintmojo/MojoTest.java
@@ -35,10 +35,10 @@ public class MojoTest {
                 FileUtils.writeStringToFile(fileToIgnore, "whatever, this should be ignored");
                 
                 LogStub log = new LogStub();
-                Mojo mojo = new Mojo("", "", 
+                Mojo mojo = new Mojo("", "",
                         projectDirectory, 
                         Collections.singletonList("src/main/resources"), 
-                        Collections.<String>emptyList(),true, null, null, null, null);
+                        Collections.<String>emptyList(), Collections.<String>emptyList(), true, null, null, null, null);
                 mojo.setLog(log);
                 
                 // when
@@ -64,7 +64,7 @@ public class MojoTest {
 			Mojo mojo = new Mojo("", "", 
 							directory, 
 							Collections.singletonList("src/main/resources/nonexistentDirectory"), 
-							Collections.<String>emptyList(),true, null, null, null, null);
+							Collections.<String>emptyList(), Collections.<String>emptyList(), true, null, null, null, null);
 			mojo.setLog(log);
 
 			// when
@@ -99,7 +99,7 @@ public class MojoTest {
 			Mojo mojo = new Mojo(null, "", 
 							directory, 
 							Collections.singletonList("src/main/resources/"), 
-							Collections.<String>emptyList(),true, "foo/bar/my-config-file.js", null, null, null);
+							Collections.<String>emptyList(), Collections.<String>emptyList(), true, "foo/bar/my-config-file.js", null, null, null);
 			
 			LogStub log = new LogStub();
 			mojo.setLog(log);


### PR DESCRIPTION
Use the Plexus FileUtils for inclusion / exclusion patterns, but still apply ignore files in the same manner for backwards compatibility.